### PR TITLE
Added variable to support Flarum database table prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# phpbb_to_flarum
-Migration Script from PHPBB to Flarum 
+# phpBB_to_Flarum
+Migration Script from phpBB to Flarum
 Discussion https://discuss.flarum.org/d/1117-phpbb-migrate-script-updated-for-0-3-and-other-improvements
 
 The Script performs a DB -> DB migration it will copy all usernames and emails and start date but *Will NOT COPY PASSWORDS* instead it will create a random passowrd which is a md5 hash of the current time that is then shad1. This means after the migration all users will need to reset their passwords
 
 
 
-## Usage Instructions 
+## Usage Instructions
 For anyone who wants to use the script here are the steps I use
 
 1. Create a fresh forum using the standard install instructions.
-2. When you create the forum make sure the email is different to the one in phbb otherwise there will be some conflicts.
+2. When you create the forum make sure the email is different to the one in phpBB otherwise there will be some conflicts.
 3. Run the my script with the correct database parameters for you. (make sure that the script is executable and the directory writable).
 
 ### Usage using phpMyAdmin tested by [demmm](https://github.com/demmm)
@@ -20,5 +20,5 @@ For anyone who wants to use the script here are the steps I use
 
 
 
-## Contributions Welcome 
+## Contributions Welcome
 Thanks to [all who have contributed](https://github.com/robrotheram/phpbb_to_flarum/graphs/contributors) :)

--- a/phpBB_to_Flarum.php
+++ b/phpBB_to_Flarum.php
@@ -1,7 +1,7 @@
 <?php
 // Original script by robrotheram from discuss.flarum.org
 // Modified by VIRUXE
-// And Reflic
+// Modified by Reflic
 // Modified by TidbitSoftware
 
 set_time_limit(0);

--- a/php_to_flaurm.php
+++ b/php_to_flaurm.php
@@ -2,6 +2,7 @@
 // Original script by robrotheram from discuss.flarum.org
 // Modified by VIRUXE
 // And Reflic
+// Modified by Tidbit Software
 
 set_time_limit(0);
 ini_set('memory_limit', -1);
@@ -14,6 +15,7 @@ $username = "user";
 $password = "password";
 $exportDBName = "PHPforums";
 $importDBName = "flarum";
+$importDBPrefix = ""; // Leave blank if you did not supply a table prefix when setting up Flarum. Otherwise, supply the full table prefix (i.e. including "_", if used).
 
 
 // Establish a connection to the server where the PHPBB database exists
@@ -83,7 +85,7 @@ if ($totalUsers)
 			$email = $row['user_email'];
 			$password = sha1(md5(time()));
 			$jointime = $row['user_regdate'];
-			$query = "INSERT INTO users (id, username, email, password, join_time, is_activated) VALUES ( '$id', '$formatedUsername', '$email', '$password', '$jointime', 1)";
+			$query = "INSERT INTO " . $importDBPrefix . "users (id, username, email, password, join_time, is_activated) VALUES ( '$id', '$formatedUsername', '$email', '$password', '$jointime', 1)";
 			$res = $importDbConnection->query($query);
 			if($res === false) {
 			  echo "Wrong SQL: " . $query . " Error: " . $importDbConnection->error . " <br/>";
@@ -115,11 +117,11 @@ if ($totalCategories)
 		$position = $i;
 		$slug = mysql_escape_mimic(slugify($row["forum_name"]));
 
-		$query = "INSERT INTO tags (id, name, description, slug, color, position) VALUES ( '$id', '$name', '$description', '$slug', '$color', '$position')";
+		$query = "INSERT INTO " . $importDBPrefix . "tags (id, name, description, slug, color, position) VALUES ( '$id', '$name', '$description', '$slug', '$color', '$position')";
 		$res = $importDbConnection->query($query);
 		if($res === false) {
 			echo "Wrong SQL Assumption id Confict now trying a update  <br/>";
-			$queryupdate = "UPDATE tags SET name = '$name', description = '$description', slug = '$slug' WHERE id = '$id' ;";
+			$queryupdate = "UPDATE " . $importDBPrefix . "tags SET name = '$name', description = '$description', slug = '$slug' WHERE id = '$id' ;";
 			$res = $importDbConnection->query($queryupdate);
 			if($res === false) { echo "Wrong SQL: " . $query . " Error: " . $importDbConnection->error . " <br/>"; }
 		}
@@ -138,7 +140,7 @@ $topicCount = $topicsQuery->num_rows;
 if($topicCount)
 {
 	$curTopicCount = 0;
-	$insertString = "INSERT INTO posts (id, user_id, discussion_id, time, type, content) VALUES \n";
+	$insertString = "INSERT INTO " . $importDBPrefix . "posts (id, user_id, discussion_id, time, type, content) VALUES \n";
 	//	Loop trough all PHPBB topics
 	$topictotal = $topicsQuery->num_rows;
 	$i = 1;
@@ -205,7 +207,7 @@ if($topicCount)
 		$topicid = $topic["topic_id"];
 		$forumid = $topic["forum_id"];
 
-		$query = "INSERT INTO discussions_tags (discussion_id, tag_id) VALUES( '$topicid', '$forumid')";
+		$query = "INSERT INTO " . $importDBPrefix . "discussions_tags (discussion_id, tag_id) VALUES( '$topicid', '$forumid')";
 		$res = $importDbConnection->query($query);
 		if($res === false) {
 			echo "Wrong SQL: " . $query . " Error: " . $importDbConnection->error . " <br/>";
@@ -218,7 +220,7 @@ if($topicCount)
 		if($result['parent_id'] > 0){
 			$topicid = $topic["topic_id"];
 			$parentid = $result['parent_id'];
-			$query = "INSERT INTO discussions_tags (discussion_id, tag_id) VALUES( '$topicid', '$parentid')";
+			$query = "INSERT INTO " . $importDBPrefix . "discussions_tags (discussion_id, tag_id) VALUES( '$topicid', '$parentid')";
 			$res = $importDbConnection->query($query);
 			if($res === false) {
 				echo "Wrong SQL: " . $query . " Error: " . $importDbConnection->error . " <br/>";
@@ -231,7 +233,7 @@ if($topicCount)
 		$slug = mysql_escape_mimic(slugify($topicTitle));
 		$count =  count($participantsArr);
 		$poster = $topic["topic_poster"];
-		$query = "INSERT INTO discussions (id, title, slug, start_time, comments_count, participants_count, start_post_id, last_post_id, start_user_id, last_user_id, last_time) VALUES( '$topicid', '$topicTitle', '$slug', '$discussionDate', '$postCount', '$count', 1, 1, '$poster', '$lastPosterID', '$discussionDate')";
+		$query = "INSERT INTO " . $importDBPrefix . "discussions (id, title, slug, start_time, comments_count, participants_count, start_post_id, last_post_id, start_user_id, last_user_id, last_time) VALUES( '$topicid', '$topicTitle', '$slug', '$discussionDate', '$postCount', '$count', 1, 1, '$poster', '$lastPosterID', '$discussionDate')";
 		$res = $importDbConnection->query($query);
 		if($res === false) {
 			echo "Wrong SQL: " . $query . " Error: " . $importDbConnection->error . " <br/>";
@@ -251,7 +253,7 @@ if ($result->num_rows > 0)
 		$comma =  $i == $total ? ";" : ",";
 		$userID = $row["user_id"];
 		$topicID = $row["topic_id"];
-		$query = "INSERT INTO users_discussions (user_id, discussion_id) VALUES ( '$userID', '$topicID')";
+		$query = "INSERT INTO " . $importDBPrefix . "users_discussions (user_id, discussion_id) VALUES ( '$userID', '$topicID')";
 		$res = $importDbConnection->query($query);
 		if($res === false) {
 			echo "Wrong SQL: " . $query . " Error: " . $importDbConnection->error . " <br/>";
@@ -280,7 +282,7 @@ if ($result->num_rows > 0)
 		$res1 = $importDbConnection->query("select * from posts where user_id = '$userID' ");
 		$numPosts =  $res1->num_rows;
 
-		$query = "UPDATE users SET discussions_count = '$numTopics',  comments_count = '$numPosts' WHERE id = '$userID' ";
+		$query = "UPDATE " . $importDBPrefix . "users SET discussions_count = '$numTopics',  comments_count = '$numPosts' WHERE id = '$userID' ";
 		$res = $importDbConnection->query($query);
 		if($res === false) {
 			echo "Wrong SQL: " . $query . " Error: " . $importDbConnection->error . " <br/>";

--- a/php_to_flaurm.php
+++ b/php_to_flaurm.php
@@ -2,7 +2,7 @@
 // Original script by robrotheram from discuss.flarum.org
 // Modified by VIRUXE
 // And Reflic
-// Modified by Tidbit Software
+// Modified by TidbitSoftware
 
 set_time_limit(0);
 ini_set('memory_limit', -1);


### PR DESCRIPTION
- Added an additional variable ($importDBPrefix) that allows the user to provide the prefix that they used when setting up their Flarum database without having to edit each `SELECT` and `UPDATE` query.
- Renamed script, including fix to spelling error ("flaurm" -> "Flarum").
- Modified comments ("phpbb" -> "phpBB").